### PR TITLE
Fix for Toast Crashes

### DIFF
--- a/Build/generate-nuget.ps1
+++ b/Build/generate-nuget.ps1
@@ -1,6 +1,6 @@
-param([string]$version="2.0.0.0")
+param([string]$version="2.5.2.0")
 
-$env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE"
+$env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE"
 $projects = "ToastNotifications", "ToastNotifications.Messages"
 $solution = "../Src/ToastNotifications.sln"
 

--- a/Src/Examples/CustomNotificationsExample/CustomCommand/CustomCommandDisplayPart.xaml
+++ b/Src/Examples/CustomNotificationsExample/CustomCommand/CustomCommandDisplayPart.xaml
@@ -1,11 +1,11 @@
 ﻿<core:NotificationDisplayPart x:Class="CustomNotificationsExample.CustomCommand.CustomCommandDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:CustomNotificationsExample.CustomCommand"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
-             mc:Ignorable="d" 
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
+             mc:Ignorable="d"
              d:DesignHeight="60" d:DesignWidth="250" Background="WhiteSmoke"
              d:DataContext="{d:DesignInstance local:CustomCommandNotification, IsDesignTimeCreatable=False}" >
     <Border BorderThickness="1" BorderBrush="LightGray">

--- a/Src/Examples/CustomNotificationsExample/CustomInput/CustomInputDisplayPart.xaml
+++ b/Src/Examples/CustomNotificationsExample/CustomInput/CustomInputDisplayPart.xaml
@@ -1,11 +1,11 @@
 ﻿<core:NotificationDisplayPart x:Class="CustomNotificationsExample.CustomInput.CustomInputDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
              xmlns:customInput="clr-namespace:CustomNotificationsExample.CustomInput"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="60" d:DesignWidth="250" Background="WhiteSmoke"
              d:DataContext="{d:DesignInstance customInput:CustomInputNotification, IsDesignTimeCreatable=False}" >
     <Border BorderThickness="1" BorderBrush="LightGray">

--- a/Src/Examples/CustomNotificationsExample/CustomMessage/CustomDisplayPart.xaml
+++ b/Src/Examples/CustomNotificationsExample/CustomMessage/CustomDisplayPart.xaml
@@ -1,10 +1,10 @@
 ﻿<core:NotificationDisplayPart x:Class="CustomNotificationsExample.CustomMessage.CustomDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:CustomNotificationsExample.CustomMessage"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
              mc:Ignorable="d"  Background="Gray"
              d:DesignHeight="60" d:DesignWidth="250"
              d:DataContext="{d:DesignInstance local:CustomNotification, IsDesignTimeCreatable=False}" >

--- a/Src/Examples/CustomNotificationsExample/MahAppsNotification/MahAppsDisplayPart.xaml
+++ b/Src/Examples/CustomNotificationsExample/MahAppsNotification/MahAppsDisplayPart.xaml
@@ -1,11 +1,11 @@
 ﻿<core:NotificationDisplayPart x:Class="CustomNotificationsExample.MahAppsNotification.MahAppsDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:CustomNotificationsExample.MahAppsNotification"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
-             mc:Ignorable="d" 
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
+             mc:Ignorable="d"
              d:DesignHeight="60" d:DesignWidth="250" Background="{DynamicResource AccentColorBrush}">
     <Grid  Margin="5">
         <Grid.RowDefinitions>

--- a/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Error/ErrorDisplayPart.xaml
@@ -1,9 +1,9 @@
 ﻿<core:NotificationDisplayPart x:Class="ToastNotifications.Messages.Error.ErrorDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
              mc:Ignorable="d" d:DesignWidth="250" >
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource ErrorColorBrush}">
         <Grid x:Name="ContentContainer">

--- a/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Information/InformationDisplayPart.xaml
@@ -1,9 +1,9 @@
 ﻿<core:NotificationDisplayPart x:Class="ToastNotifications.Messages.Information.InformationDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications" 
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
              mc:Ignorable="d" d:DesignWidth="250"  >
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource InformationColorBrush}">
         <Grid x:Name="ContentContainer">

--- a/Src/ToastNotifications.Messages/Properties/AssemblyInfo.cs
+++ b/Src/ToastNotifications.Messages/Properties/AssemblyInfo.cs
@@ -7,12 +7,12 @@ using System.Windows;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ToastNotifications.Messages")]
+[assembly: AssemblyTitle("ToastNotifications.Messages-Axion")]
 [assembly: AssemblyDescription("Toast notifications messages for WPF")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("DevCrew.pl Rafał Łopatka")]
+[assembly: AssemblyCompany("DevCrew.pl Rafał Łopatka and Axion BioSystems")]
 [assembly: AssemblyProduct("ToastNotifications.Messages")]
-[assembly: AssemblyCopyright("Copyright © Rafał Łopatka  2019")]
+[assembly: AssemblyCopyright("Copyright © Rafał Łopatka  2019 and Axion Biosystems")]
 [assembly: AssemblyTrademark("Rafał Łopatka")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.1.0")]
-[assembly: AssemblyFileVersion("2.5.1.0")]
+[assembly: AssemblyVersion("2.5.2.0")]
+[assembly: AssemblyFileVersion("2.5.2.0")]

--- a/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Success/SuccessDisplayPart.xaml
@@ -1,9 +1,9 @@
 ﻿<core:NotificationDisplayPart x:Class="ToastNotifications.Messages.Success.SuccessDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
              mc:Ignorable="d" d:DesignWidth="250"  >
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource SuccessColorBrush}">
         <Grid x:Name="ContentContainer">

--- a/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
+++ b/Src/ToastNotifications.Messages/ToastNotifications.Messages.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{4DE2F314-B19F-423E-92D8-7D3A7D9ACEA2}</ProjectGuid>
     <OutputType>library</OutputType>
     <RootNamespace>ToastNotifications.Messages</RootNamespace>
-    <AssemblyName>ToastNotifications.Messages</AssemblyName>
+    <AssemblyName>ToastNotifications.Messages-Axion</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -35,7 +35,7 @@
     <ApplicationIcon>toast-notifications-icon.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="('$(Configuration)' == 'Release') And ('$(UseTemporarySignCert)' != 'true')">
     <AssemblyOriginatorKeyFile>../../Build/DevCrew.ToastNotifications.pfx</AssemblyOriginatorKeyFile>
@@ -124,13 +124,13 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Resource Include="toast-notifications-icon.ico" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\ToastNotifications\ToastNotifications.csproj">
       <Project>{4a8879fc-9a6e-4904-910b-5c13fa5ed5be}</Project>
       <Name>ToastNotifications</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="toast-notifications-icon.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Src/ToastNotifications.Messages/ToastNotifications.Messages.nuspec
+++ b/Src/ToastNotifications.Messages/ToastNotifications.Messages.nuspec
@@ -25,7 +25,7 @@
     <references></references>
     <tags>WPF notifications, Toast notifications, XAML notifications, c# notifications, UI notifications, ToastNotifications, toasts, messages, notifications, WPF, XAML, UI, notify, message, toast</tags>
     <dependencies>
-        <dependency id="ToastNotifications" version="$version$" />
+        <dependency id="ToastNotifications-Axion" version="$version$" />
     </dependencies>
   </metadata>
 </package>

--- a/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml
+++ b/Src/ToastNotifications.Messages/Warning/WarningDisplayPart.xaml
@@ -1,9 +1,9 @@
 ﻿<core:NotificationDisplayPart x:Class="ToastNotifications.Messages.Warning.WarningDisplayPart"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications"
+             xmlns:core="clr-namespace:ToastNotifications.Core;assembly=ToastNotifications-Axion"
              mc:Ignorable="d" d:DesignWidth="250" >
 
     <Border x:Name="ContentWrapper" Style="{DynamicResource NotificationBorder}" Background="{DynamicResource WarningColorBrush}">

--- a/Src/ToastNotifications/Position/ControlPositionProvider.cs
+++ b/Src/ToastNotifications/Position/ControlPositionProvider.cs
@@ -36,8 +36,21 @@ namespace ToastNotifications.Position
             if (source?.CompositionTarget == null)
                 return new Point(0, 0);
 
+            var elementSource = PresentationSource.FromVisual(_element);
+            if (elementSource == null)
+                return new Point(0, 0);
+
             Matrix transform = source.CompositionTarget.TransformFromDevice;
-            Point location = transform.Transform(_element.PointToScreen(new Point(0, 0)));
+            Point location;
+
+            try
+            {
+                location = transform.Transform(_element.PointToScreen(new Point(0, 0)));
+            }
+            catch (InvalidOperationException)
+            {
+                return new Point(0, 0);
+            }
 
             switch (_corner)
             {

--- a/Src/ToastNotifications/Properties/AssemblyInfo.cs
+++ b/Src/ToastNotifications/Properties/AssemblyInfo.cs
@@ -7,12 +7,12 @@ using System.Windows;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("ToastNotifications")]
+[assembly: AssemblyTitle("ToastNotifications-Axion")]
 [assembly: AssemblyDescription("Toast notifications for WPF")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("DevCrew.pl Rafał Łopatka")]
+[assembly: AssemblyCompany("DevCrew.pl Rafał Łopatka and Axion BioSystems")]
 [assembly: AssemblyProduct("ToastNotifications")]
-[assembly: AssemblyCopyright("Copyright © Rafał Łopatka  2019")]
+[assembly: AssemblyCopyright("Copyright © Rafał Łopatka  2019 and Axion BioSystems")]
 [assembly: AssemblyTrademark("Rafał Łopatka")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.1.0")]
-[assembly: AssemblyFileVersion("2.5.1.0")]
+[assembly: AssemblyVersion("2.5.2.0")]
+[assembly: AssemblyFileVersion("2.5.2.0")]

--- a/Src/ToastNotifications/ToastNotifications.csproj
+++ b/Src/ToastNotifications/ToastNotifications.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{4A8879FC-9A6E-4904-910B-5C13FA5ED5BE}</ProjectGuid>
     <OutputType>library</OutputType>
     <RootNamespace>ToastNotifications</RootNamespace>
-    <AssemblyName>ToastNotifications</AssemblyName>
+    <AssemblyName>ToastNotifications-Axion</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -35,7 +35,7 @@
     <ApplicationIcon>toast-notifications-icon.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup Condition="('$(Configuration)' == 'Release') And ('$(UseTemporarySignCert)' != 'true')">
     <AssemblyOriginatorKeyFile>../../Build/DevCrew.ToastNotifications.pfx</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
I'll call out the specific issue below. This PR does a bunch - it updates the libraries to look like "ToastNotifications-Axion", uses a new version number, and updates the linkages/assembly references between Toast Notifications and the Toast Notifications Messages class.

The gist of the problem was that the anchor element that the toast messages is relative to will sometimes not be bound to a presentation object. I don't fully know what that means. But when it does, an unexpected exception is thrown and our app crashes.

This was reported in a few bugs:

NAV-4893
NAV-4596

I have submitted part of this code change to the actual Toast Notifications library people. But, in the meantime, this would let us get a patched version in our code.

The hope is that if accepted, we'll just switch to their library as soon as this is sorted out.