### PR TITLE
Don't crash if client calls Close() on a disposed object

### DIFF
--- a/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
+++ b/Src/ToastNotifications/Display/NotificationsDisplaySupervisor.cs
@@ -61,6 +61,11 @@ namespace ToastNotifications.Display
 
         private void InternalClose(INotification notification)
         {
+            //Handle a case where client calls CustomMessage.Close() 
+            //but this object has already been disposed
+            if (_lifetimeSupervisor == null)
+                return;
+
             _lifetimeSupervisor.CloseNotification(notification);
             UpdateWindowPosition();
         }


### PR DESCRIPTION
- Check for null in NotificationsDisplaySupervisor.InternalClose

Fixes https://axionbio.jira.com/browse/NAV-6264